### PR TITLE
Driver should be versioned separately for dev build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
       <dependency>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver</artifactId>
-        <version>${neo4j.version}</version>
+        <version>4.3.3</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
As neo4j-java-driver is not part of the monorepo it should be versioned separately.